### PR TITLE
fix: wrong field of TaskInformation used

### DIFF
--- a/domain/plan.go
+++ b/domain/plan.go
@@ -167,7 +167,7 @@ func (p *Plan) JobSpecification() (JobSpecification, error) {
 		taskInfo := TaskInformation{
 			Id:       task.Id.Hex(),
 			Title:    task.Title,
-			Selector: task.Subjects,
+			Schedule: task.Schedule,
 		}
 
 		for _, activity := range task.Activities {

--- a/domain/runtime.go
+++ b/domain/runtime.go
@@ -26,7 +26,7 @@ type JobSpecification struct {
 type TaskInformation struct {
 	Id         string                `json:"id"`
 	Title      string                `json:"title"`
-	Schedule   string                `json:"schedule"`
+	Schedule   []string              `json:"schedule"`
 	Activities []ActivityInformation `json:"activities"`
 }
 


### PR DESCRIPTION
TaskInformation{} does not have a `Selector` field. It should be `Schedule` of type `[] string`