### PR TITLE
Migrate away from different base images to enabled CGO

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 .vscode
 .github
 .env*
+local.go
+test.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,9 @@ COPY . ./
 RUN make swag
 
 # Build it
-RUN CGO_ENABLED=0 GOOS=linux go build -o /configuration-service
+RUN GOOS=linux go build -o /configuration-service
 
-FROM alpine AS production
+FROM golang:1.23 AS production
 WORKDIR /
 
 COPY --from=builder /configuration-service /configuration-service


### PR DESCRIPTION
We need CGO enabled for the moment for the SQLite3 database. This unfortunately causes the alpine image to not be able to run the binary.
This PR switches the base image for the production run to the normal Golang image