### PR TITLE
Add password option for user creation

### DIFF
--- a/cmd/users/create.go
+++ b/cmd/users/create.go
@@ -3,13 +3,12 @@ package users
 import (
 	"crypto/rand"
 	"errors"
-	"math/big"
-
 	"github.com/compliance-framework/configuration-service/internal/config"
 	"github.com/compliance-framework/configuration-service/internal/service"
 	"github.com/compliance-framework/configuration-service/internal/service/relational"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"math/big"
 )
 
 func newUserAddCmd() *cobra.Command {
@@ -28,6 +27,8 @@ func newUserAddCmd() *cobra.Command {
 
 	cmd.Flags().StringP("last-name", "l", "", "Last name of the user (required)")
 	cmd.MarkFlagRequired("last-name")
+
+	cmd.Flags().StringP("password", "p", "", "Password of the user")
 
 	return cmd
 }
@@ -62,10 +63,19 @@ func addUser(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	password, err := generatePassword(12) // Generate a random password of length 12
-	if err != nil {
-		sugar.Errorw("Failed to generate password", "error", err)
-		return
+	var password string
+	if ok := cmd.Flags().Changed("password"); ok {
+		password, err = cmd.Flags().GetString("password")
+		if err != nil {
+			sugar.Errorw("Failed to get password", "error", err)
+			return
+		}
+	} else {
+		password, err = generatePassword(12) // Generate a random password of length 12
+		if err != nil {
+			sugar.Errorw("Failed to generate password", "error", err)
+			return
+		}
 	}
 
 	newUser := relational.User{

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	go.mongodb.org/mongo-driver v1.17.2
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.37.0
+	golang.org/x/term v0.31.0
 	gopkg.in/yaml.v2 v2.4.0
 	gorm.io/datatypes v1.2.5
 	gorm.io/driver/postgres v1.5.7


### PR DESCRIPTION
Allowing a password option for user creation command, allows us ot have consistency for demoes specifying a static password usable when spinning up a fresh install 